### PR TITLE
## [0.4.9]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.4.9]
+
+* workaround about wrong selection position of WidgetSpan
+
 ## [0.4.8]
 
 * fix issue that ImageSpan's padding can't be null. 

--- a/lib/src/render_object/extended_text_render_box.dart
+++ b/lib/src/render_object/extended_text_render_box.dart
@@ -236,23 +236,30 @@ abstract class ExtendedTextRenderBox extends RenderBox
     if (handleSpecialText) {
       ///if first index, check by first span
       var offset = textPosition.offset;
-      if (offset <= 0) {
-        offset = 1;
-      }
-
-      ///last or has ExtendedWidgetSpan
-
       var boxs = textPainter.getBoxesForSelection(TextSelection(
-          baseOffset: offset - 1,
-          extentOffset: offset,
+          baseOffset: offset,
+          extentOffset: offset + 1,
           affinity: textPosition.affinity));
       if (boxs.length > 0) {
         var rect = boxs.toList().last.toRect();
         caretHeightCallBack?.call(rect.height);
-        if (textPosition.offset <= 0) {
-          return rect.topLeft + effectiveOffset;
-        } else {
-          return rect.topRight + effectiveOffset;
+        return rect.topLeft + effectiveOffset;
+      } else {
+        if (offset <= 0) {
+          offset = 1;
+        }
+        boxs = textPainter.getBoxesForSelection(TextSelection(
+            baseOffset: offset - 1,
+            extentOffset: offset,
+            affinity: textPosition.affinity));
+        if (boxs.length > 0) {
+          var rect = boxs.toList().last.toRect();
+          caretHeightCallBack?.call(rect.height);
+          if (textPosition.offset <= 0) {
+            return rect.topLeft + effectiveOffset;
+          } else {
+            return rect.topRight + effectiveOffset;
+          }
         }
       }
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: extended_text_library
 description: package library for extended_text and extended_text_field,provide common base class.
-version: 0.4.8
+version: 0.4.9
 author: zmtzawq <zmtzawqlp@live.com>
 homepage: https://github.com/fluttercandies/extended_text_library
 


### PR DESCRIPTION
* workaround about wrong selection position of WidgetSpan
refer to https://github.com/fluttercandies/extended_text_field/issues/21