### PR TITLE
Upgrade for Flutter 1.26.0-17.3.pre

### DIFF
--- a/lib/src/selection/cupertino_text_selection_controls.dart
+++ b/lib/src/selection/cupertino_text_selection_controls.dart
@@ -481,14 +481,14 @@ class ExtendedCupertinoTextSelectionControls extends TextSelectionControls {
   /// Builder for iOS-style copy/paste text selection toolbar.
   @override
   Widget buildToolbar(
-    BuildContext context,
-    Rect globalEditableRegion,
-    double textLineHeight,
-    Offset position,
-    List<TextSelectionPoint> endpoints,
-    TextSelectionDelegate delegate,
-    ClipboardStatusNotifier clipboardStatus,
-  ) {
+      BuildContext context,
+      Rect globalEditableRegion,
+      double textLineHeight,
+      Offset position,
+      List<TextSelectionPoint> endpoints,
+      TextSelectionDelegate delegate,
+      ClipboardStatusNotifier clipboardStatus,
+      Offset _) {
     assert(debugCheckHasMediaQuery(context));
     final MediaQueryData mediaQuery = MediaQuery.of(context);
 

--- a/lib/src/selection/extended_text_selection_overlay.dart
+++ b/lib/src/selection/extended_text_selection_overlay.dart
@@ -346,14 +346,14 @@ class ExtendedTextSelectionOverlay {
         showWhenUnlinked: false,
         offset: -editingRegion.topLeft,
         child: selectionControls.buildToolbar(
-          context,
-          editingRegion,
-          renderObject.preferredLineHeight,
-          midpoint,
-          endpoints,
-          selectionDelegate,
-          clipboardStatus,
-        ),
+            context,
+            editingRegion,
+            renderObject.preferredLineHeight,
+            midpoint,
+            endpoints,
+            selectionDelegate,
+            clipboardStatus,
+            null),
       ),
     );
   }

--- a/lib/src/selection/material_text_selection_controls.dart
+++ b/lib/src/selection/material_text_selection_controls.dart
@@ -77,15 +77,17 @@ class ExtendedMaterialTextSelectionToolbarState
         height: kMinInteractiveDimension,
         minWidth: kMinInteractiveDimension,
       ),
-      child: FlatButton(
+      child: TextButton(
         onPressed: itemData.onPressed,
-        padding: EdgeInsets.only(
-          // These values were eyeballed to match the native text selection menu
-          // on a Pixel 2 running Android 10.
-          left: 9.5 + (isFirst ? 5.0 : 0.0),
-          right: 9.5 + (isLast ? 5.0 : 0.0),
+        style: TextButton.styleFrom(
+          padding: EdgeInsets.only(
+            // These values were eyeballed to match the native text selection menu
+            // on a Pixel 2 running Android 10.
+            left: 9.5 + (isFirst ? 5.0 : 0.0),
+            right: 9.5 + (isLast ? 5.0 : 0.0),
+          ),
+          shape: const ContinuousRectangleBorder(side: BorderSide.none),
         ),
-        shape: Border.all(width: 0.0, color: Colors.transparent),
         child: Text(itemData.label),
       ),
     );
@@ -760,14 +762,14 @@ class ExtendedMaterialTextSelectionControls extends TextSelectionControls {
   /// Builder for material-style copy/paste text selection toolbar.
   @override
   Widget buildToolbar(
-    BuildContext context,
-    Rect globalEditableRegion,
-    double textLineHeight,
-    Offset selectionMidpoint,
-    List<TextSelectionPoint> endpoints,
-    TextSelectionDelegate delegate,
-    ClipboardStatusNotifier clipboardStatus,
-  ) {
+      BuildContext context,
+      Rect globalEditableRegion,
+      double textLineHeight,
+      Offset selectionMidpoint,
+      List<TextSelectionPoint> endpoints,
+      TextSelectionDelegate delegate,
+      ClipboardStatusNotifier clipboardStatus,
+      Offset _) {
     assert(debugCheckHasMediaQuery(context));
     assert(debugCheckHasMaterialLocalizations(context));
 
@@ -830,7 +832,7 @@ class ExtendedMaterialTextSelectionControls extends TextSelectionControls {
       height: _kHandleSize,
       child: CustomPaint(
         painter: ExtendedMaterialTextSelectionHandlePainter(
-          color: Theme.of(context).textSelectionHandleColor,
+          color: Theme.of(context).textSelectionTheme.selectionHandleColor,
         ),
       ),
     );


### PR DESCRIPTION
I wanted to use extended_text on current Flutter beta channel so I edited the library to not use any deprecated APIs.
extended_text_library had to be edited as well so here's the awaited pull request 😁