### PR TITLE
bug fix: the triggering of onDragSelectionUpdate will cause other effects

### DIFF
--- a/lib/src/selection/extended_text_selection.dart
+++ b/lib/src/selection/extended_text_selection.dart
@@ -331,16 +331,7 @@ class ExtendedTextSelectionGestureDetectorBuilder {
   ///  * [TextSelectionGestureDetector.onDragSelectionUpdate], which triggers
   ///    this callback./lib/src/material/text_field.dart
   @protected
-  void onDragSelectionUpdate(TapDragUpdateDetails details) {
-    if (!delegate.selectionEnabled) {
-      return;
-    }
-    renderEditable.selectPositionAt(
-      from: details.localOffsetFromOrigin,
-      to: details.localPosition,
-      cause: SelectionChangedCause.drag,
-    );
-  }
+  void onDragSelectionUpdate(TapDragUpdateDetails details) {}
 
   /// Handler for [TextSelectionGestureDetector.onDragSelectionEnd].
   ///


### PR DESCRIPTION
### Steps to reproduce  

Flutter 3.10.0  

Move your finger quickly through the text (don't long press).  

### Expected results

No effect needed  

<details><summary>Details</summary>
<p>

| extended_text | extended_text_field1 |  
| --- | --- |  
| <video src="https://github.com/fluttercandies/extended_text_library/assets/32262985/61d914ae-d89d-42a8-8403-b847703d66b3"></video> | <video src="https://github.com/fluttercandies/extended_text_library/assets/32262985/e9e39953-e832-49a0-b4cb-66005717930f"></video> |  

</p>
</details> 

### Actual results

<details><summary>Details</summary>
<p>

| extended_text | extended_text_field |  
| --- | --- |  
| <video src="https://github.com/fluttercandies/extended_text_library/assets/32262985/e58f8d9d-e925-4870-936d-9860c9a7db1f"></video> | <video src="https://github.com/fluttercandies/extended_text_library/assets/32262985/7fc8ef51-413b-4139-a023-68fad6ce5630"></video> |  

</p>
</details> 