### PR TITLE
Expose the Focus.onKeyEvent to SpecialTextSpanBuilder.handleKeyEventCallback to give it a chance to handle keyboard events

### DIFF
--- a/lib/src/special_text_span_builder.dart
+++ b/lib/src/special_text_span_builder.dart
@@ -70,7 +70,7 @@ abstract class SpecialTextSpanBuilder {
 
   /// The SpecialTextSpanBuilder.handleKeyEventCallback event gives the user a chance to process keyboard input
   KeyEventResult handleKeyEventCallback(FocusNode node, KeyEvent event) {
-    return KeyEventResult.skipRemainingHandlers;
+    return KeyEventResult.ignored;
   }
 }
 

--- a/lib/src/special_text_span_builder.dart
+++ b/lib/src/special_text_span_builder.dart
@@ -67,6 +67,11 @@ abstract class SpecialTextSpanBuilder {
   bool isStart(String value, String startFlag) {
     return value.endsWith(startFlag);
   }
+
+  /// The SpecialTextSpanBuilder.handleKeyEventCallback event gives the user a chance to process keyboard input
+  KeyEventResult handleKeyEventCallback(FocusNode node, KeyEvent event) {
+    return KeyEventResult.skipRemainingHandlers;
+  }
 }
 
 abstract class SpecialText {


### PR DESCRIPTION
Expose the Focus.onKeyEvent to SpecialTextSpanBuilder.handleKeyEventCallback to give it a chance to handle keyboard events